### PR TITLE
Earlier `revert_on_error` bailout for checks and execution

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3388,6 +3388,25 @@ impl Bank {
         error_counters: &mut TransactionErrorMetrics,
         processing_config: TransactionProcessingConfig,
     ) -> LoadAndExecuteTransactionsOutput {
+        self.load_and_execute_transactions_with_revert_on_error(
+            batch,
+            max_age,
+            timings,
+            error_counters,
+            processing_config,
+            false, // revert_on_error
+        )
+    }
+
+    pub fn load_and_execute_transactions_with_revert_on_error(
+        &self,
+        batch: &TransactionBatch<impl TransactionWithMeta>,
+        max_age: usize,
+        timings: &mut ExecuteTimings,
+        error_counters: &mut TransactionErrorMetrics,
+        processing_config: TransactionProcessingConfig,
+        revert_on_error: bool,
+    ) -> LoadAndExecuteTransactionsOutput {
         let sanitized_txs = batch.sanitized_transactions();
 
         let (check_results, check_us) = measure_us!(self.check_transactions(
@@ -3410,12 +3429,13 @@ impl Bank {
 
         let sanitized_output = self
             .transaction_processor
-            .load_and_execute_sanitized_transactions(
+            .load_and_execute_sanitized_transactions_with_revert_on_error(
                 self,
                 sanitized_txs,
                 check_results,
                 &processing_environment,
                 &processing_config,
+                revert_on_error,
             );
 
         // Accumulate the errors returned by the batch processor.

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -318,6 +318,28 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         environment: &TransactionProcessingEnvironment,
         config: &TransactionProcessingConfig,
     ) -> LoadAndExecuteSanitizedTransactionsOutput {
+        self.load_and_execute_sanitized_transactions_with_revert_on_error(
+            callbacks,
+            sanitized_txs,
+            check_results,
+            environment,
+            config,
+            false,
+        )
+    }
+
+    /// Main entrypoint to the SVM.
+    pub fn load_and_execute_sanitized_transactions_with_revert_on_error<
+        CB: TransactionProcessingCallback,
+    >(
+        &self,
+        callbacks: &CB,
+        sanitized_txs: &[impl SVMTransaction],
+        check_results: Vec<TransactionCheckResult>,
+        environment: &TransactionProcessingEnvironment,
+        config: &TransactionProcessingConfig,
+        revert_on_error: bool,
+    ) -> LoadAndExecuteSanitizedTransactionsOutput {
         // If `check_results` does not have the same length as `sanitized_txs`,
         // transactions could be truncated as a result of `.iter().zip()` in
         // many of the below methods.
@@ -406,7 +428,13 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         // With SIMD83, transactions must be executed in order, because transactions
         // in the same batch may modify the same accounts. Transaction order is
         // preserved within entries written to the ledger.
+        let mut will_revert_error: Option<TransactionError> = Option::None;
         for (tx, check_result) in sanitized_txs.iter().zip(check_results) {
+            if let Some(reverted_error) = will_revert_error.as_ref() {
+                processing_results.push(Err(reverted_error.clone()));
+                continue;
+            }
+
             let (validate_result, validate_fees_us) =
                 measure_us!(check_result.and_then(|tx_details| {
                     Self::validate_transaction_nonce_and_fee_payer(
@@ -513,6 +541,10 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                 measure_us!(balance_collector.collect_post_balances(&mut account_loader, tx));
             execute_timings
                 .saturating_add_in_place(ExecuteTimingType::CollectBalancesUs, collect_balances_us);
+
+            if revert_on_error && processing_result.is_err() {
+                will_revert_error = Some(processing_result.as_ref().unwrap_err().clone());
+            }
 
             processing_results.push(processing_result);
         }


### PR DESCRIPTION
If checks or execution fails; don't waste time on the rest of the bundle.